### PR TITLE
Create timeline saving options

### DIFF
--- a/src/main/java/com/icthh/xm/ms/timeline/config/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/config/ApplicationProperties.java
@@ -22,6 +22,7 @@ public class ApplicationProperties {
     private String kafkaSystemQueue;
     private String tenantPropertiesPathPattern;
     private String tenantPropertiesName;
+    private String timelineServiceImpl;
 
     @Getter
     @Setter

--- a/src/main/java/com/icthh/xm/ms/timeline/config/ServiceConfiguration.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/config/ServiceConfiguration.java
@@ -1,0 +1,41 @@
+package com.icthh.xm.ms.timeline.config;
+
+import com.icthh.xm.commons.tenant.TenantContextHolder;
+import com.icthh.xm.ms.timeline.repository.cassandra.EntityMappingRepository;
+import com.icthh.xm.ms.timeline.repository.cassandra.TimelineRepository;
+import com.icthh.xm.ms.timeline.service.timeline.TimelineService;
+import com.icthh.xm.ms.timeline.service.timeline.TimelineServiceCassandraImpl;
+import com.icthh.xm.ms.timeline.service.timeline.TimelineServiceLoggerImpl;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = "com.icthh.xm")
+@RequiredArgsConstructor
+public class ServiceConfiguration {
+
+    private final ApplicationProperties applicationProperties;
+
+    private static final String CASSANDRA_IMPL = "cassandra";
+    private static final String LOGGER_IMPL = "logger";
+    private static final String H2DB_IMPL = "h2db";
+    private static final String POSTGRES_IMPL = "postgresdb";
+
+    @Bean
+    public TimelineService timelineService(TimelineRepository timelineRepository,
+                                              EntityMappingRepository entityMappingRepository,
+                                              TenantContextHolder tenantContextHolder) {
+
+        switch (applicationProperties.getTimelineServiceImpl()) {
+            case CASSANDRA_IMPL: return new TimelineServiceCassandraImpl(timelineRepository, entityMappingRepository, tenantContextHolder);
+            case LOGGER_IMPL: return new TimelineServiceLoggerImpl();
+            case H2DB_IMPL: throw new NotImplementedException("Strategy " + applicationProperties.getTimelineServiceImpl() + " not implemented");
+            case POSTGRES_IMPL: throw new NotImplementedException("Strategy " + applicationProperties.getTimelineServiceImpl() + " not implemented");
+            default: return new TimelineServiceCassandraImpl(timelineRepository, entityMappingRepository, tenantContextHolder);
+        }
+    }
+
+}

--- a/src/main/java/com/icthh/xm/ms/timeline/repository/kafka/TimelineEventConsumer.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/repository/kafka/TimelineEventConsumer.java
@@ -8,7 +8,7 @@ import com.icthh.xm.commons.tenant.TenantContextHolder;
 import com.icthh.xm.commons.tenant.TenantContextUtils;
 import com.icthh.xm.ms.timeline.domain.XmTimeline;
 import com.icthh.xm.ms.timeline.service.TenantPropertiesService;
-import com.icthh.xm.ms.timeline.service.TimelineService;
+import com.icthh.xm.ms.timeline.service.timeline.TimelineService;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/icthh/xm/ms/timeline/service/timeline/TimelineService.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/service/timeline/TimelineService.java
@@ -1,0 +1,20 @@
+package com.icthh.xm.ms.timeline.service.timeline;
+
+import com.icthh.xm.ms.timeline.domain.XmTimeline;
+import com.icthh.xm.ms.timeline.web.rest.vm.TimelinePageVM;
+
+import java.time.Instant;
+
+public interface TimelineService {
+
+    TimelinePageVM getTimelines(String msName,
+                                String userKey,
+                                String idOrKey,
+                                Instant dateFrom,
+                                Instant dateTo,
+                                String operation,
+                                String next,
+                                int limit);
+
+    void insertTimelines(XmTimeline xmTimeline);
+}

--- a/src/main/java/com/icthh/xm/ms/timeline/service/timeline/TimelineServiceCassandraImpl.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/service/timeline/TimelineServiceCassandraImpl.java
@@ -1,4 +1,4 @@
-package com.icthh.xm.ms.timeline.service;
+package com.icthh.xm.ms.timeline.service.timeline;
 
 import com.icthh.xm.commons.tenant.TenantContextHolder;
 import com.icthh.xm.commons.tenant.TenantContextUtils;
@@ -12,13 +12,12 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 
-@Service
-public class TimelineService {
+public class TimelineServiceCassandraImpl implements TimelineService {
     private TimelineRepository timelineRepository;
     private EntityMappingRepository entityMappingRepository;
     private TenantContextHolder tenantContextHolder;
 
-    public TimelineService(
+    public TimelineServiceCassandraImpl(
                     TimelineRepository timelineRepository,
                     EntityMappingRepository entityMappingRepository,
                     TenantContextHolder tenantContextHolder) {
@@ -39,6 +38,7 @@ public class TimelineService {
      * @param limit     the limit per page
      * @return page with timelines and next page code
      */
+    @Override
     public TimelinePageVM getTimelines(String msName,
                                        String userKey,
                                        String idOrKey,
@@ -79,6 +79,7 @@ public class TimelineService {
      * Insert timelines.
      * @param xmTimeline  the timeline
      */
+    @Override
     public void insertTimelines(XmTimeline xmTimeline) {
         insertIdAndKey(xmTimeline);
         if (StringUtils.isBlank(xmTimeline.getOperationName())) {

--- a/src/main/java/com/icthh/xm/ms/timeline/service/timeline/TimelineServiceLoggerImpl.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/service/timeline/TimelineServiceLoggerImpl.java
@@ -1,0 +1,57 @@
+package com.icthh.xm.ms.timeline.service.timeline;
+
+import com.icthh.xm.ms.timeline.domain.XmTimeline;
+import com.icthh.xm.ms.timeline.domain.ext.IdOrKey;
+import com.icthh.xm.ms.timeline.web.rest.vm.TimelinePageVM;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+@Slf4j
+public class TimelineServiceLoggerImpl implements TimelineService {
+
+    private ArrayBlockingQueue<XmTimeline> timelines = new ArrayBlockingQueue(100);
+
+    private static boolean stringFilter(String filter, String value) {
+        return isNotBlank(filter) ? StringUtils.equalsIgnoreCase(filter, value) : true;
+    }
+
+    @Override
+    public TimelinePageVM getTimelines(String msName, String userKey, String idOrKey, Instant dateFrom, Instant dateTo, String operation, String next, int limit) {
+
+        // filter and return timelines from memory
+
+        List filteredTimelines = timelines.stream()
+            .filter(t -> stringFilter(msName, t.getMsName()))
+            .filter(t -> stringFilter(userKey, t.getUserKey()))
+            .filter(t -> stringFilter(operation, t.getOperationName()))
+            .filter(t -> {
+                if (isNotBlank(idOrKey)) {
+                    IdOrKey idOrKeyObj = IdOrKey.of(idOrKey);
+
+                    if (idOrKeyObj.isId()) {
+                        return idOrKeyObj.getId().equals(t.getEntityId());
+                    }
+                }
+
+                return true;
+            })
+            .filter(t -> dateFrom != null ? dateFrom.isBefore(t.getStartDate()) || dateFrom.equals(t.getStartDate()) : true)
+            .filter(t -> dateTo != null ? dateTo.isAfter(t.getStartDate()) || dateTo.equals(t.getStartDate()) : true)
+            .collect(Collectors.toList());
+
+        return new TimelinePageVM(filteredTimelines, null);
+    }
+
+    @Override
+    public void insertTimelines(XmTimeline xmTimeline) {
+        timelines.add(xmTimeline);
+        log.info("Event {}", xmTimeline);
+    }
+}

--- a/src/main/java/com/icthh/xm/ms/timeline/web/rest/XmTimelineResource.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/web/rest/XmTimelineResource.java
@@ -1,7 +1,7 @@
 package com.icthh.xm.ms.timeline.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import com.icthh.xm.ms.timeline.service.TimelineService;
+import com.icthh.xm.ms.timeline.service.timeline.TimelineService;
 import com.icthh.xm.ms.timeline.web.rest.vm.TimelinePageVM;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -127,6 +127,10 @@ application:
     tenant-ignored-path-list: /v2/api-docs, /api/profile-info, /swagger-resources/configuration/ui, /management/health
     kafka-system-topic: system_topic
     kafka-system-queue: system_queue
+    # =============================
+    # options [cassandra, logger]
+    # =============================
+    timeline-service-impl: cassandra
     retry:
         max-attempts: 3
         delay: 1000 #in milliseconds

--- a/src/test/java/com/icthh/xm/ms/timeline/service/TimelineServiceCassandraUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/timeline/service/TimelineServiceCassandraUnitTest.java
@@ -12,6 +12,7 @@ import com.icthh.xm.commons.tenant.TenantKey;
 import com.icthh.xm.ms.timeline.domain.XmTimeline;
 import com.icthh.xm.ms.timeline.repository.cassandra.EntityMappingRepository;
 import com.icthh.xm.ms.timeline.repository.cassandra.TimelineRepository;
+import com.icthh.xm.ms.timeline.service.timeline.TimelineServiceCassandraImpl;
 import com.icthh.xm.ms.timeline.web.rest.vm.TimelinePageVM;
 
 import org.junit.Before;
@@ -21,7 +22,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Optional;
 
-public class TimelineServiceUnitTest {
+public class TimelineServiceCassandraUnitTest {
 
     private static final String MS_NAME = "test";
     private static final String USER_KEY = "test";
@@ -36,7 +37,7 @@ public class TimelineServiceUnitTest {
     private TimelineRepository timelineRepository;
     private EntityMappingRepository entityMappingRepository;
     private TenantContextHolder tenantContextHolder;
-    private TimelineService timelineService;
+    private TimelineServiceCassandraImpl timelineService;
     private TenantContext tenantContext;
 
     @Before
@@ -45,7 +46,7 @@ public class TimelineServiceUnitTest {
         timelineRepository = mock(TimelineRepository.class);
         entityMappingRepository = mock(EntityMappingRepository.class);
         tenantContextHolder = mock(TenantContextHolder.class);
-        timelineService = new TimelineService(timelineRepository, entityMappingRepository,
+        timelineService = new TimelineServiceCassandraImpl(timelineRepository, entityMappingRepository,
                         tenantContextHolder);
         tenantContext = mock(TenantContext.class);
         when(tenantContext.getTenantKey()).thenReturn(Optional.of(TenantKey.valueOf(TENANT)));

--- a/src/test/java/com/icthh/xm/ms/timeline/service/TimelineServiceLoggerUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/timeline/service/TimelineServiceLoggerUnitTest.java
@@ -1,0 +1,49 @@
+package com.icthh.xm.ms.timeline.service;
+
+import com.icthh.xm.ms.timeline.domain.XmTimeline;
+import com.icthh.xm.ms.timeline.service.timeline.TimelineServiceLoggerImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+
+public class TimelineServiceLoggerUnitTest {
+
+    private TimelineServiceLoggerImpl timelineService;
+    private XmTimeline timeline;
+
+    private static final String MS_NAME = "test_ms_name";
+    private static final String USER_KEY = "test_user_key";
+    private static final Instant DATE = Instant.now();
+    private static final String OPERATION = "test_operation";
+    private static final Long ENTITY_ID_LONG = 111L;
+    private static final String ENTITY_KEY = "test_entity_key";
+
+    @Before
+    public void init() {
+        timelineService = new TimelineServiceLoggerImpl();
+        timeline = createTestTimeline();
+    }
+
+    @Test
+    public void testLoggerTimelineService() {
+        timelineService.insertTimelines(timeline);
+        Assertions.assertThat(timelineService.getTimelines(MS_NAME, USER_KEY, ENTITY_ID_LONG.toString(), DATE, DATE, OPERATION, null, 0).getTimelines()).hasSize(1);
+        Assertions.assertThat(timelineService.getTimelines(null, null, null, null, null, null, null, 0).getTimelines()).hasSize(1);
+        Assertions.assertThat(timelineService.getTimelines("WRONG_MS_NAME", USER_KEY, ENTITY_ID_LONG.toString(), DATE, DATE, OPERATION, null, 0).getTimelines()).hasSize(0);
+    }
+
+    private XmTimeline createTestTimeline() {
+        XmTimeline timeline = new XmTimeline();
+        timeline.setMsName(MS_NAME);
+        timeline.setRid("id");
+        timeline.setUserKey(USER_KEY);
+        timeline.setEntityId(ENTITY_ID_LONG);
+        timeline.setEntityKey(ENTITY_KEY);
+        timeline.setStartDate(DATE);
+        timeline.setOperationName(OPERATION);
+
+        return timeline;
+    }
+}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -110,4 +110,4 @@ application:
     tenant-properties-path-pattern: /config/tenants/{tenantName}/timeline/${tenant-properties-name}
     tenant-properties-name: timeline.yml
     kafka-system-queue: system_queue
-
+    timeline-service-impl: cassandra


### PR DESCRIPTION
Created a new timelines saving policy. It is possible to change timeline storage by changing "TimelineService" implementation.
Available config options:
- "cassandra" (saving timelines in cassandra. Default behavior.)
- "logger" (write timelines in log file and saving last 100 timelines in stack)
- "h2db" (saving in H2 database. NOT IMPLEMENTED YET)
- "postgresdb" (saving in postgresql database. NOT IMPLEMENTED YET)