### PR TITLE
Remove JdbcTypeCode annotations from XmTimeline fields

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=timeline
 profile=dev
-version=4.0.16
+version=4.0.17
 
 # Dependency versions
 jhipsterDependenciesVersion=8.6.0

--- a/src/main/java/com/icthh/xm/ms/timeline/domain/XmTimeline.java
+++ b/src/main/java/com/icthh/xm/ms/timeline/domain/XmTimeline.java
@@ -143,19 +143,16 @@ public class XmTimeline implements Serializable {
     @Column(name = "source")
     private String source;
 
-    @JdbcTypeCode(SqlTypes.JSON)
     @JsonDeserialize(using = UntypedObjectDeserializer.class)
     @Convert(converter = MapToStringConverter.class)
     @Column(name = "data")
     private Map<String, Object> data = new HashMap<>();
 
-    @JdbcTypeCode(SqlTypes.JSON)
     @JsonDeserialize(using = UntypedObjectDeserializer.class)
     @Convert(converter = MapToStringConverter.class)
     @Column(name = "entity_before")
     private Map<String, Object> entityBefore = new HashMap<>();
 
-    @JdbcTypeCode(SqlTypes.JSON)
     @JsonDeserialize(using = UntypedObjectDeserializer.class)
     @Convert(converter = MapToStringConverter.class)
     @Column(name = "entity_after")


### PR DESCRIPTION
## Summary

Fix Oracle error:

```
java.sql.SQLFeatureNotSupportedException: Unsupported feature: getBytes
```

## Root Cause

Hibernate's `@JdbcTypeCode(SqlTypes.JSON)` uses `OracleJsonBlobJdbcType` (BLOB-based) for Oracle,
while the actual column type is **CLOB** — causing an invalid `getBytes()` JDBC call.

Reference: https://discourse.hibernate.org/t/mapping-string-to-json-pg-and-clob-oracle-rs-getbytes-error/8388

## Solution

Removed `@JdbcTypeCode(SqlTypes.JSON)` and replaced with:

```java
@Convert(converter = MapToStringConverter.class)
```

JSON is now stored as a plain **String**, compatible with all supported databases.

## Impact

| Database   | Before                        | After                          |
|------------|-------------------------------|--------------------------------|
| Oracle     | ❌ BLOB/CLOB mismatch → error | ✅ CLOB via String converter   |
| PostgreSQL | ✅ Works (TEXT/jsonb)         | ✅ Works (implicit text cast)  |
| Elastic    | ✅ Works                      | ✅ No impact (Map<String, Object>) |

Reference: https://www.postgresql.org/docs/current/datatype-json.html

## Conclusion

Safe, minimal change:
- ✅ Fixes Oracle `SQLFeatureNotSupportedException`
- ✅ Preserves existing PostgreSQL behaviour
- ✅ No impact on Elastic
